### PR TITLE
Fix dark-mode toggle flicker by load-and-swap stylesheet

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -10,7 +10,7 @@
     {% endif %}
   {% endunless %}
 
-  <link rel="stylesheet" href="{{ '/assets/css/just-the-docs-default.css' | relative_url }}">
+  <link id="jtd-theme-stylesheet" rel="stylesheet" href="{{ '/assets/css/just-the-docs-default.css' | relative_url }}">
 
   {% if site.ga_tracking != nil %}
     <script async src="https://www.googletagmanager.com/gtag/js?id={{ site.ga_tracking }}"></script>

--- a/assets/js/just-the-docs.js
+++ b/assets/js/just-the-docs.js
@@ -488,13 +488,31 @@ function searchLoaded(index, docs) {
 // Switch theme
 
 jtd.getTheme = function() {
-  var cssFileHref = document.querySelector('[rel="stylesheet"]').getAttribute('href');
+  var cssFile = document.getElementById('jtd-theme-stylesheet') || document.querySelector('[rel="stylesheet"]');
+  var cssFileHref = cssFile.getAttribute('href');
   return cssFileHref.substring(cssFileHref.lastIndexOf('-') + 1, cssFileHref.length - 4);
 }
 
 jtd.setTheme = function(theme) {
-  var cssFile = document.querySelector('[rel="stylesheet"]');
-  cssFile.setAttribute('href', '{{ "assets/css/just-the-docs-" | absolute_url }}' + theme + '.css');
+  var cssFile = document.getElementById('jtd-theme-stylesheet') || document.querySelector('[rel="stylesheet"]');
+  var nextHref = '{{ "assets/css/just-the-docs-" | absolute_url }}' + theme + '.css';
+
+  if (cssFile.getAttribute('href') === nextHref) {
+    setCookie('user-colorscheme',theme,365);
+    changeGiscusTheme(theme);
+    return;
+  }
+
+  var nextCssFile = cssFile.cloneNode();
+  nextCssFile.setAttribute('href', nextHref);
+  nextCssFile.setAttribute('id', 'jtd-theme-stylesheet-next');
+
+  nextCssFile.addEventListener('load', function() {
+    cssFile.remove();
+    nextCssFile.setAttribute('id', 'jtd-theme-stylesheet');
+  });
+
+  cssFile.parentNode.insertBefore(nextCssFile, cssFile.nextSibling);
   setCookie('user-colorscheme',theme,365);
   changeGiscusTheme(theme);
 }


### PR DESCRIPTION
### Motivation
- Toggling dark mode caused a brief unstyled flash because the theme stylesheet `href` was replaced directly, which can produce flicker during load. 
- The change aims to swap themes without removing the active stylesheet until the new stylesheet has fully loaded.

### Description
- Add a stable id to the theme link tag by updating `_includes/head.html` to include `id="jtd-theme-stylesheet"` on the main stylesheet link. 
- Update `jtd.getTheme()` to read the current stylesheet from the element with `id="jtd-theme-stylesheet"` when available. 
- Replace direct `href` mutation in `jtd.setTheme()` (in `assets/js/just-the-docs.js`) with a clone-and-insert strategy that sets the new `href` on a cloned link, waits for its `load` event, then removes the old link and renames the clone; also short-circuits if the requested theme is already active. 
- Preserve existing cookie handling via `setCookie('user-colorscheme',...)` and `changeGiscusTheme(theme)` behavior.

### Testing
- Ran `npm test`, which failed due to pre-existing `stylelint` issues in unrelated SCSS files; no new SCSS files were added by this change. 
- No additional automated test suites were present or executed for JavaScript runtime behavior in this repo.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0925b8307c833385b42dc50e44aca5)