### PR TITLE
Add Vedabase BG links and apply global verse-ordering rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,4 @@
   - `> <a href="...Discourse_N#Y" target="_blank">Besant</a>: [exact sentence(s)]`
   - `**Comment**: *1–2 lines on why immoral or nonsensical.*`
 - If strongly relevant to more than one topic, cite in both places.
-- On caste pages, place the strongest casteist verse first rather than strict numeric order.
+- In every page and subsection (for all books), place the most immoral / most nonsensical and strongest verse first, rather than strict numeric order.

--- a/docs/immorality/caste-system.md
+++ b/docs/immorality/caste-system.md
@@ -58,8 +58,9 @@ Translations:
 Translations:
 
 > <a href="https://en.wikisource.org/wiki/Bhagavad-Gita_(Besant_4th)/Discourse_3#35" target="_blank">Besant</a>: Better is one's own duty, though devoid of merit, than the duty of another well discharged. Better is death in one's own duty; the duty of another is full of danger.
+> <a href="https://vedabase.io/en/library/bg/3/35/" target="_blank">As It Is</a>: It is far better to discharge one’s prescribed duties, even though faultily, than another’s duties perfectly. Destruction in the course of performing one’s own duty is better than engaging in another’s duties, for to follow another’s path is dangerous.
 
-**Comment**: *This supports caste-bound duty by treating role-crossing as morally dangerous. It discourages freedom to choose work outside inherited social expectations.*
+**Comment**: *This supports caste-bound duty by treating role-crossing as morally dangerous. It discourages freedom to choose work outside inherited social expectations. Besant and As It Is use different English style, but the core claim is linguistically the same: your own prescribed duty (svadharma) is better, and another’s duty is dangerous.*
 
 ### BG 4.13
 {: .no_toc }

--- a/docs/immorality/human.md
+++ b/docs/immorality/human.md
@@ -27,14 +27,16 @@ permalink: /immorality/cruelty/human/
 Translations:
 
 > <a href="https://en.wikisource.org/wiki/Bhagavad-Gita_(Besant_4th)/Discourse_2#31" target="_blank">Besant</a>: Looking to thine own duty thou shouldst not tremble, for there is no greater good for a Kshattriya than righteous war.
+> <a href="https://vedabase.io/en/library/bg/2/31/" target="_blank">As It Is</a>: Considering your specific duty as a kṣatriya, you should know that there is no better engagement for you than fighting on religious principles; and so there is no need for hesitation.
 
-**Comment**: *This verse moralizes war as sacred duty and pressures people to fight based on class duty rather than human empathy.*
+**Comment**: *This verse moralizes war as sacred duty and pressures people to fight based on class duty rather than human empathy. Besant’s “righteous war” and As It Is “fighting on religious principles” differ in phrasing, but not in core meaning.*
 
 ### BG 2.37
 {: .no_toc }
 Translations:
 
 > <a href="https://en.wikisource.org/wiki/Bhagavad-Gita_(Besant_4th)/Discourse_2#37" target="_blank">Besant</a>: Slain, thou gainest heaven; victorious, thou enjoyest the earth; therefore stand up, O son of Kuntî, resolved to fight.
+> <a href="https://vedabase.io/en/library/bg/2/37/" target="_blank">As It Is</a>: O son of Kuntī, either you will be killed on the battlefield and attain the heavenly planets, or you will conquer and enjoy the earthly kingdom. Therefore, get up and fight with determination.
 
 **Comment**: *It frames both killing and dying as desirable outcomes, which can normalize violence instead of minimizing harm.*
 
@@ -43,6 +45,7 @@ Translations:
 Translations:
 
 > <a href="https://en.wikisource.org/wiki/Bhagavad-Gita_(Besant_4th)/Discourse_2#38" target="_blank">Besant</a>: Holding pleasure and pain, gain and loss, victory and defeat as equal, then prepare for battle, and thus thou shalt not incur sin.
+> <a href="https://vedabase.io/en/library/bg/2/38/" target="_blank">As It Is</a>: Do thou fight for the sake of fighting, without considering happiness or distress, loss or gain, victory or defeat — and by so doing you shall never incur sin.
 
 **Comment**: *This attempts to remove moral guilt from warfare by changing mindset, which is ethically dangerous.*
 

--- a/docs/nonsense/logic.md
+++ b/docs/nonsense/logic.md
@@ -28,6 +28,7 @@ permalink: /nonsense/logic/
 Translations:
 
 > <a href="https://en.wikisource.org/wiki/Bhagavad-Gita_(Besant_4th)/Discourse_2#12" target="_blank">Besant</a>: Nor at any time verily was I not, nor thou, nor these lords of men; nor verily shall we ever cease to be hereafter.
+> <a href="https://vedabase.io/en/library/bg/2/12/" target="_blank">As It Is</a>: Never was there a time when I did not exist, nor you, nor all these kings; nor in the future shall any of us cease to be.
 
 **Comment**: *This claims eternal personal existence without evidence, making it a metaphysical assertion rather than a logical conclusion.*
 
@@ -36,6 +37,7 @@ Translations:
 Translations:
 
 > <a href="https://en.wikisource.org/wiki/Bhagavad-Gita_(Besant_4th)/Discourse_2#22" target="_blank">Besant</a>: As a man casteth off worn-out clothes and putteth on others that are new, so the embodied casteth off worn-out bodies and entereth into others that are new.
+> <a href="https://vedabase.io/en/library/bg/2/22/" target="_blank">As It Is</a>: As a person puts on new garments, giving up old ones, the soul similarly accepts new material bodies, giving up the old and useless ones.
 
 **Comment**: *Rebirth is asserted as fact through analogy, but analogy is not proof.*
 
@@ -44,6 +46,7 @@ Translations:
 Translations:
 
 > <a href="https://en.wikisource.org/wiki/Bhagavad-Gita_(Besant_4th)/Discourse_2#23" target="_blank">Besant</a>: Weapons cleave him not, fire burneth him not, waters wet him not, wind drieth him not.
+> <a href="https://vedabase.io/en/library/bg/2/23/" target="_blank">As It Is</a>: The soul can never be cut to pieces by any weapon, nor burned by fire, nor moistened by water, nor withered by the wind.
 
 **Comment**: *This describes an entity that is physically unaffected by all physical processes, which is not testable or evidenced.*
 
@@ -52,8 +55,9 @@ Translations:
 Translations:
 
 > <a href="https://en.wikisource.org/wiki/Bhagavad-Gita_(Besant_4th)/Discourse_3#14" target="_blank">Besant</a>: From food creatures come forth; from rain food is produced; from sacrifice ariseth rain; sacrifice is born of action.
+> <a href="https://vedabase.io/en/library/bg/3/14/" target="_blank">As It Is</a>: All living bodies subsist on food grains, which are produced from rains. Rains are produced by performance of yajña [sacrifice], and yajña is born of prescribed duties.
 
-**Comment**: *The claim that sacrifice causes rain is a pre-scientific causal assertion that conflicts with meteorology.*
+**Comment**: *The claim that sacrifice causes rain is a pre-scientific causal assertion that conflicts with meteorology. As It Is adds “prescribed duties” and “yajña” wording, but the causal chain is effectively the same as Besant.*
 
 ## Ramayana
 


### PR DESCRIPTION
### Motivation
- Ensure the Bhagavad Gita verses already cited from Besant also include the Vedabase (`vedabase.io`) translation for cross-reference and verification.
- Clarify whether differences between Besant and "As It Is" are stylistic or substantive for readers of the critical commentary.
- Apply a consistent ordering policy across the site so the most immoral/most nonsensical entries appear first in every page and subsection.

### Description
- Updated `README.md` to change the ordering guidance from "On caste pages..." to a global rule: "In every page and subsection (for all books), place the most immoral / most nonsensical and strongest verse first.".
- Added Vedabase (`vedabase.io`) translation links and corresponding lines beside existing Besant links for `BG 3.35` in `docs/immorality/caste-system.md` and updated the comment to note phrasing vs meaning.
- Added Vedabase links for `BG 2.31`, `BG 2.37`, and `BG 2.38` in `docs/immorality/human.md` and for `BG 2.12`, `BG 2.22`, `BG 2.23`, and `BG 3.14` in `docs/nonsense/logic.md`, and updated comments to mention differences where relevant.
- Staged and committed the edits with the message `Add Vedabase BG links and broaden verse-ordering guidance`.

### Testing
- Ran `git status --short` to verify changed files were detected and staged successfully. 
- Committed the changes with `git commit -m "Add Vedabase BG links and broaden verse-ordering guidance"` which completed successfully. 
- Created PR metadata via `make_pr` which generated the PR title and body summarizing the changes successfully. 
- No automated site build or test suite was invoked as part of this patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0928acd2e48333811c4a9c06089968)