### PR TITLE
Move global verse-ordering guidance to common README section

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
     <p align="center">Theme: <a href="https://github.com/just-the-docs/just-the-docs">just-the-docs</a></p>
 </p>
 
+## Common citation and ordering notes (all books/pages)
+
+- In every page and subsection (for all books), place the most immoral / most nonsensical and strongest verse first, rather than strict numeric order.
+
 ## Bhagavad Gita citation notes
 
 - Current base text for new additions: Besant 4th edition on Wikisource.
@@ -15,4 +19,3 @@
   - `> <a href="...Discourse_N#Y" target="_blank">Besant</a>: [exact sentence(s)]`
   - `**Comment**: *1–2 lines on why immoral or nonsensical.*`
 - If strongly relevant to more than one topic, cite in both places.
-- In every page and subsection (for all books), place the most immoral / most nonsensical and strongest verse first, rather than strict numeric order.


### PR DESCRIPTION
### Motivation
- The site-wide rule about ordering verses by strongest/most immoral/most nonsensical impact was scoped under Bhagavad Gita notes but applies to all books and pages, so it should live in a common location.

### Description
- Added `## Common citation and ordering notes (all books/pages)` to `README.md`, inserted the rule `- In every page and subsection (for all books), place the most immoral / most nonsensical and strongest verse first, rather than strict numeric order.` under it, and removed the duplicate line from the `## Bhagavad Gita citation notes` section.

### Testing
- Ran `rg -n "In every page and subsection|Bhagavad Gita citation notes|citation notes|most immoral|most nonsensical|strongest verse" -S .`, inspected `git diff -- README.md`, and committed the change with `git commit`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a092a0539688333a54ff6e354741ea1)