### PR TITLE
Clarify Bhagavad Gita citation ordering and variant preference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@
 
 ## Bhagavad Gita citation notes
 
-- Current base text for new additions: Besant 4th edition on Wikisource.
+- For every new Bhagavad Gita citation, always add Besant 4th edition on Wikisource first.
+- After Besant, always add the "Bhagavad-gītā As It Is" version (this is required, not optional).
 - Add verses in relevant topical files/subsections (not as a single dump list).
 - Use this consistent entry structure:
   - Verse heading: `### BG X.Y`
@@ -19,3 +20,4 @@
   - `> <a href="...Discourse_N#Y" target="_blank">Besant</a>: [exact sentence(s)]`
   - `**Comment**: *1–2 lines on why immoral or nonsensical.*`
 - If strongly relevant to more than one topic, cite in both places.
+- If the quoted verse wording differs significantly from what is discussed in the commentary, prefer the more linguistically accurate rendering and briefly mention the variant.


### PR DESCRIPTION
### Motivation
- Clarify and enforce citation ordering and preferred translations when adding Bhagavad Gita verses to the repository.

### Description
- Update README to require adding Besant 4th edition on Wikisource first, then `Bhagavad-gītā As It Is`, and to prefer linguistically accurate renderings when quoted wording differs from the commentary.

### Testing
- No automated tests were run for this documentation change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a092ace8bb883338f7fea654397f1f2)