### PR TITLE
Fix merged quote formatting between Besant and As It Is citations

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 
 - For every new Bhagavad Gita citation, always add Besant 4th edition on Wikisource first.
 - After Besant, always add the "Bhagavad-gītā As It Is" version (this is required, not optional).
+- Keep one empty line between the Besant quote block and the As It Is quote block so they render as two separate quotes (not one merged quote).
 - Add verses in relevant topical files/subsections (not as a single dump list).
 - Use this consistent entry structure:
   - Verse heading: `### BG X.Y`

--- a/docs/immorality/caste-system.md
+++ b/docs/immorality/caste-system.md
@@ -58,6 +58,7 @@ Translations:
 Translations:
 
 > <a href="https://en.wikisource.org/wiki/Bhagavad-Gita_(Besant_4th)/Discourse_3#35" target="_blank">Besant</a>: Better is one's own duty, though devoid of merit, than the duty of another well discharged. Better is death in one's own duty; the duty of another is full of danger.
+
 > <a href="https://vedabase.io/en/library/bg/3/35/" target="_blank">As It Is</a>: It is far better to discharge one’s prescribed duties, even though faultily, than another’s duties perfectly. Destruction in the course of performing one’s own duty is better than engaging in another’s duties, for to follow another’s path is dangerous.
 
 **Comment**: *This supports caste-bound duty by treating role-crossing as morally dangerous. It discourages freedom to choose work outside inherited social expectations. Besant and As It Is use different English style, but the core claim is linguistically the same: your own prescribed duty (svadharma) is better, and another’s duty is dangerous.*

--- a/docs/immorality/human.md
+++ b/docs/immorality/human.md
@@ -27,6 +27,7 @@ permalink: /immorality/cruelty/human/
 Translations:
 
 > <a href="https://en.wikisource.org/wiki/Bhagavad-Gita_(Besant_4th)/Discourse_2#31" target="_blank">Besant</a>: Looking to thine own duty thou shouldst not tremble, for there is no greater good for a Kshattriya than righteous war.
+
 > <a href="https://vedabase.io/en/library/bg/2/31/" target="_blank">As It Is</a>: Considering your specific duty as a kṣatriya, you should know that there is no better engagement for you than fighting on religious principles; and so there is no need for hesitation.
 
 **Comment**: *This verse moralizes war as sacred duty and pressures people to fight based on class duty rather than human empathy. Besant’s “righteous war” and As It Is “fighting on religious principles” differ in phrasing, but not in core meaning.*
@@ -36,6 +37,7 @@ Translations:
 Translations:
 
 > <a href="https://en.wikisource.org/wiki/Bhagavad-Gita_(Besant_4th)/Discourse_2#37" target="_blank">Besant</a>: Slain, thou gainest heaven; victorious, thou enjoyest the earth; therefore stand up, O son of Kuntî, resolved to fight.
+
 > <a href="https://vedabase.io/en/library/bg/2/37/" target="_blank">As It Is</a>: O son of Kuntī, either you will be killed on the battlefield and attain the heavenly planets, or you will conquer and enjoy the earthly kingdom. Therefore, get up and fight with determination.
 
 **Comment**: *It frames both killing and dying as desirable outcomes, which can normalize violence instead of minimizing harm.*
@@ -45,6 +47,7 @@ Translations:
 Translations:
 
 > <a href="https://en.wikisource.org/wiki/Bhagavad-Gita_(Besant_4th)/Discourse_2#38" target="_blank">Besant</a>: Holding pleasure and pain, gain and loss, victory and defeat as equal, then prepare for battle, and thus thou shalt not incur sin.
+
 > <a href="https://vedabase.io/en/library/bg/2/38/" target="_blank">As It Is</a>: Do thou fight for the sake of fighting, without considering happiness or distress, loss or gain, victory or defeat — and by so doing you shall never incur sin.
 
 **Comment**: *This attempts to remove moral guilt from warfare by changing mindset, which is ethically dangerous.*

--- a/docs/nonsense/logic.md
+++ b/docs/nonsense/logic.md
@@ -28,6 +28,7 @@ permalink: /nonsense/logic/
 Translations:
 
 > <a href="https://en.wikisource.org/wiki/Bhagavad-Gita_(Besant_4th)/Discourse_2#12" target="_blank">Besant</a>: Nor at any time verily was I not, nor thou, nor these lords of men; nor verily shall we ever cease to be hereafter.
+
 > <a href="https://vedabase.io/en/library/bg/2/12/" target="_blank">As It Is</a>: Never was there a time when I did not exist, nor you, nor all these kings; nor in the future shall any of us cease to be.
 
 **Comment**: *This claims eternal personal existence without evidence, making it a metaphysical assertion rather than a logical conclusion.*
@@ -37,6 +38,7 @@ Translations:
 Translations:
 
 > <a href="https://en.wikisource.org/wiki/Bhagavad-Gita_(Besant_4th)/Discourse_2#22" target="_blank">Besant</a>: As a man casteth off worn-out clothes and putteth on others that are new, so the embodied casteth off worn-out bodies and entereth into others that are new.
+
 > <a href="https://vedabase.io/en/library/bg/2/22/" target="_blank">As It Is</a>: As a person puts on new garments, giving up old ones, the soul similarly accepts new material bodies, giving up the old and useless ones.
 
 **Comment**: *Rebirth is asserted as fact through analogy, but analogy is not proof.*
@@ -46,6 +48,7 @@ Translations:
 Translations:
 
 > <a href="https://en.wikisource.org/wiki/Bhagavad-Gita_(Besant_4th)/Discourse_2#23" target="_blank">Besant</a>: Weapons cleave him not, fire burneth him not, waters wet him not, wind drieth him not.
+
 > <a href="https://vedabase.io/en/library/bg/2/23/" target="_blank">As It Is</a>: The soul can never be cut to pieces by any weapon, nor burned by fire, nor moistened by water, nor withered by the wind.
 
 **Comment**: *This describes an entity that is physically unaffected by all physical processes, which is not testable or evidenced.*
@@ -55,6 +58,7 @@ Translations:
 Translations:
 
 > <a href="https://en.wikisource.org/wiki/Bhagavad-Gita_(Besant_4th)/Discourse_3#14" target="_blank">Besant</a>: From food creatures come forth; from rain food is produced; from sacrifice ariseth rain; sacrifice is born of action.
+
 > <a href="https://vedabase.io/en/library/bg/3/14/" target="_blank">As It Is</a>: All living bodies subsist on food grains, which are produced from rains. Rains are produced by performance of yajña [sacrifice], and yajña is born of prescribed duties.
 
 **Comment**: *The claim that sacrifice causes rain is a pre-scientific causal assertion that conflicts with meteorology. As It Is adds “prescribed duties” and “yajña” wording, but the causal chain is effectively the same as Besant.*


### PR DESCRIPTION
### Motivation
- Prevent consecutive Besant/As It Is quote lines from being rendered as a single merged blockquote so the two source translations are displayed as separate quotes.

### Description
- Inserted an empty line between the Besant and the Bhagavad-gītā “As It Is” quote blocks in `docs/immorality/caste-system.md`, `docs/immorality/human.md`, and `docs/nonsense/logic.md` so Markdown renders them as two separate quotes.
- Added a README rule requiring one empty line between the Besant quote block and the As It Is quote block to avoid this formatting mistake in future edits.

### Testing
- Ran the search script `python - <<'PY'\nfrom pathlib import Path\nimport re\nfor p in Path('docs').rglob('*.md'):\n    t=p.read_text()\n    if re.search(r'Besant</a>:[^\\n]*\\n> ?<a href="https://vedabase.io/en/library/bg/', t):\n        print(p)\nPY` and confirmed there were no matches (no adjacent Besant→As It Is quote lines remain).
- Inspected the modified files with `nl -ba` to verify the inserted blank lines and the new README guidance are present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0933d2ee10833397abeb42bd13d6e8)